### PR TITLE
Import Commands with defined namespace fix

### DIFF
--- a/lenvendo-commands.php
+++ b/lenvendo-commands.php
@@ -10,4 +10,4 @@ $console = new Console(new Input());
 
 $status = $console->handle();
 
-//$console->terminate($status);
+$console->terminate($status);

--- a/src/Commands/BeautifyInputInfoCommand.php
+++ b/src/Commands/BeautifyInputInfoCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Lenvendo\ConsoleCommands\Commands;
+
 use Lenvendo\ConsoleCommands\Console\Command;
 
 class BeautifyInputInfoCommand extends Command
@@ -18,15 +20,22 @@ class BeautifyInputInfoCommand extends Command
     {
         $this->writeln([
             'Called command: ' . $this->name,
-            '',
-            'Arguments',
         ]);
+
+        if (!empty($this->arguments())) {
+            $this->writeln([
+                '',
+                'Arguments:',
+            ]);
+        }
 
         foreach ($this->arguments() as $argument) {
             $this->writeln('    -  ' . $argument);
         }
 
-        $this->writeln('Options:');
+        if (!empty($this->options())) {
+            $this->writeln('Options:');
+        }
 
         foreach ($this->options() as $name => $value) {
             $this->writeln('    -  ' . $name);


### PR DESCRIPTION
    - Commands with defined namespace were not importing, now this feature is usable and Commands can be placed in a namespace;
    - Some changes have been made to BeatifyInputInfoCommand.